### PR TITLE
Ignore wget errors on fetching mirror lists

### DIFF
--- a/apkfastestmirror.sh
+++ b/apkfastestmirror.sh
@@ -367,7 +367,7 @@ echo "${3}" | awk -v v="${v}" '
         print $1 v "/community"
         print "@edge_main " $1 "edge" "/main"
         print "@edge_community " $1 "edge" "/community"
-        print "@edge_testing " $1 "edge" "/testing"
+        print "#@edge_testing " $1 "edge" "/testing"
     }
 ' | output_results
 

--- a/apkfastestmirror.sh
+++ b/apkfastestmirror.sh
@@ -365,9 +365,9 @@ echo "${3}" | awk -v v="${v}" '
     {
         print $1 v "/main"
         print $1 v "/community"
-        print "#@edge_main " $1 "edge" "/main"
-        print "#@edge_community " $1 "edge" "/community"
-        print "#@edge_testing " $1 "edge" "/testing"
+        print "@edge_main " $1 "edge" "/main"
+        print "@edge_community " $1 "edge" "/community"
+        print "@edge_testing " $1 "edge" "/testing"
     }
 ' | output_results
 

--- a/apkfastestmirror.sh
+++ b/apkfastestmirror.sh
@@ -209,7 +209,7 @@ mirrorlist="
 ${mirrors_custom}
 $(
     for source in ${mirrorlist_sources}; do \
-        wget -O- -q -Y ${http_use_proxy} -T ${http_timeout} ${source}; \
+        wget 2>/dev/null -O- -q -Y ${http_use_proxy} -T ${http_timeout} ${source}; \
     done \
     | sort \
     | uniq \

--- a/apkfastestmirror.sh
+++ b/apkfastestmirror.sh
@@ -365,8 +365,8 @@ echo "${3}" | awk -v v="${v}" '
     {
         print $1 v "/main"
         print $1 v "/community"
-        print "@edge_main " $1 "edge" "/main"
-        print "@edge_community " $1 "edge" "/community"
+        print "#@edge_main " $1 "edge" "/main"
+        print "#@edge_community " $1 "edge" "/community"
         print "#@edge_testing " $1 "edge" "/testing"
     }
 ' | output_results


### PR DESCRIPTION
Some of the mirrors time out and at least one returns forbidden when attempting to download the mirrors list file.

The output from wget errors here doesn't seem useful ("wget: download timed out" and "wget: server returned error: HTTP/1.1 403 Forbidden"). So, having the warnings/errors sent to /dev/null seems appropriate.